### PR TITLE
Add support for LDAPS & Misc fixes

### DIFF
--- a/lldap-chart/Chart.yaml
+++ b/lldap-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/lldap-chart/Chart.yaml
+++ b/lldap-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/lldap-chart/Chart.yaml
+++ b/lldap-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/lldap-chart/Chart.yaml
+++ b/lldap-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/lldap-chart/Chart.yaml
+++ b/lldap-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lldap-chart
-description: A Helm chart for Kubernetes
+description: lldap - Light LDAP implementation for authentication
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.1"
+appVersion: 0.6.1

--- a/lldap-chart/Chart.yaml
+++ b/lldap-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "0.6.1"

--- a/lldap-chart/README.md
+++ b/lldap-chart/README.md
@@ -15,7 +15,7 @@ A Helm chart for deploying [lldap](https://github.com/nitnelave/lldap) a lightwe
 
 ## Prerequisites
 
-- Kubernetes cluster 
+- Kubernetes cluster
 - Helm
 
 ## Installation
@@ -59,6 +59,7 @@ The following table lists the configurable parameters of the lldap chart and the
 | `env.TZ`                                | Timezone for the application                                 | `"CET"`                               |
 | `env.GID`                               | Group ID                                                     | `"1001"`                              |
 | `env.UID`                               | User ID                                                      | `"1001"`                              |
+| `extraEnv`                              | Extra environment variables to be set on lldap container     | `[]`                                  |
 | `persistence.enabled`                   | Enable persistent storage                                    | `true`                                |
 | `persistence.storageClassName`          | Storage class name                                           | `""`                                  |
 | `persistence.storageSize`               | Storage size                                                 | `"100Mi"`                             |

--- a/lldap-chart/README.md
+++ b/lldap-chart/README.md
@@ -33,7 +33,6 @@ A Helm chart for deploying [lldap](https://github.com/nitnelave/lldap) a lightwe
 
    ```
 
-
 ## Uninstallation
 
 To uninstall/delete the `lldap` deployment:
@@ -50,49 +49,51 @@ The following table lists the configurable parameters of the lldap chart and the
 
 ### Parameters
 
-| Parameter                               | Description                                                  | Default Value                         |
-|-----------------------------------------|--------------------------------------------------------------|---------------------------------------|
-| `replicaCount`                          | Number of replicas                                           | `1`                                   |
-| `image.repository`                      | Image repository                                             | `"nitnelave/lldap"`                   |
-| `image.tag`                             | Image tag                                                    | `"latest"`                            |
-| `image.pullPolicy`                      | Image pull policy                                            | `"IfNotPresent"`                      |
-| `env.TZ`                                | Timezone for the application                                 | `"CET"`                               |
-| `env.GID`                               | Group ID                                                     | `"1001"`                              |
-| `env.UID`                               | User ID                                                      | `"1001"`                              |
-| `extraEnv`                              | Extra environment variables to be set on lldap container     | `[]`                                  |
-| `persistence.enabled`                   | Enable persistent storage                                    | `true`                                |
-| `persistence.storageClassName`          | Storage class name                                           | `""`                                  |
-| `persistence.storageSize`               | Storage size                                                 | `"100Mi"`                             |
-| `persistence.accessMode`                | Access mode for the PVC                                      | `"ReadWriteOnce"`                     |
-| `persistence.localPath`                 | Local filesystem path for storage                            | `""`                                  |
-| `persistence.manualProvision`           | Manually provision a PersistentVolume                        | `false`                               |
-| `resources`                             | Resource limits and requests                                 | `{}`                                  |
-| `nodeSelector`                          | Node labels for pod assignment                               | `{}`                                  |
-| `tolerations`                           | Tolerations for pod assignment                               | `[]`                                  |
-| `affinity`                              | Affinity for pod assignment                                  | `{}`                                  |
-| `hpa.enabled`                           | Enable Horizontal Pod Autoscaler (HPA)                       | `true`                                |
-| `hpa.minReplicas`                       | Minimum number of replicas                                   | `1`                                   |
-| `hpa.maxReplicas`                       | Maximum number of replicas                                   | `3`                                   |
-| `hpa.targetCPUUtilizationPercentage`    | Target CPU utilization percentage for HPA                    | `60`                                  |
-| `hpa.targetMemoryUtilizationPercentage` | Target memory utilization percentage for HPA                 | `60`                                  |
-| `service.name`                          | Name of the Kubernetes service                               | `"lldap-service"`                     |
-| `service.type`                          | Service type                                                 | `"ClusterIP"`                         |
-| `service.ports`                         | List of service ports                                        | See `values.yaml`                     |
-| `ingress.enabled`                       | Enable Ingress                                               | `false`                               |
-| `ingress.name`                          | Name of the Ingress resource                                 | `"lldap-web-ingress"`                 |
-| `ingress.ingressClassName`              | Ingress class name                                           | `"nginx"`                             |
-| `ingress.annotations`                   | Annotations for the Ingress                                  | `{}`                                  |
-| `ingress.labels`                        | Labels for the Ingress                                       | `{}`                                  |
-| `ingress.hosts`                         | List of host configurations                                  | See `values.yaml`                     |
-| `ingress.tls`                           | TLS configuration for the Ingress                            | See `values.yaml`                     |
-| `secret.create`                         | Create a new secret for credentials                          | `true`                                |
-| `secret.name`                           | Name of the secret                                           | `"lldap-credentials"`                 |
-| `secret.lldapJwtSecret`                 | JWT secret for LLDAP                                         | `"wobY6RK/Dc0vL21zFiIZs9iyVy0NQ3ldijYPQ4HLWTc="` |
-| `secret.lldapUserName`                  | Username for the LDAP user                                   | `"admin"`                             |
-| `secret.lldapUserPass`                  | Password for the LDAP user                                   | `"admiistrator123456"`                |
-| `secret.lldapBaseDn`                    | Base DN for LDAP                                             | `"dc=homelab,dc=es"`                  |
-| `secret.useExisting`                    | Use an existing secret                                       | `false`                               |
-| `secret.existingSecretName`             | Name of the existing secret                                  | `""`                                  |
+| Parameter                               | Description                                                | Default Value                                    |
+| --------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------ |
+| `replicaCount`                          | Number of replicas                                         | `1`                                              |
+| `image.repository`                      | Image repository                                           | `"nitnelave/lldap"`                              |
+| `image.tag`                             | Image tag                                                  | `"latest"`                                       |
+| `image.pullPolicy`                      | Image pull policy                                          | `"IfNotPresent"`                                 |
+| `env.TZ`                                | Timezone for the application                               | `"CET"`                                          |
+| `env.GID`                               | Group ID                                                   | `"1001"`                                         |
+| `env.UID`                               | User ID                                                    | `"1001"`                                         |
+| `extraEnv`                              | Extra environment variables to be set on lldap container   | `[]`                                             |
+| `persistence.enabled`                   | Enable persistent storage                                  | `true`                                           |
+| `persistence.storageClassName`          | Storage class name                                         | `""`                                             |
+| `persistence.storageSize`               | Storage size                                               | `"100Mi"`                                        |
+| `persistence.accessMode`                | Access mode for the PVC                                    | `"ReadWriteOnce"`                                |
+| `persistence.localPath`                 | Local filesystem path for storage                          | `""`                                             |
+| `persistence.manualProvision`           | Manually provision a PersistentVolume                      | `false`                                          |
+| `extraVolumes`                          | Extra list of additional volumes for lldap pod             | `[]`                                             |
+| `extraVolumeMounts`                     | Extra list of additional volume mounts for lldap container | `[]`                                             |
+| `resources`                             | Resource limits and requests                               | `{}`                                             |
+| `nodeSelector`                          | Node labels for pod assignment                             | `{}`                                             |
+| `tolerations`                           | Tolerations for pod assignment                             | `[]`                                             |
+| `affinity`                              | Affinity for pod assignment                                | `{}`                                             |
+| `hpa.enabled`                           | Enable Horizontal Pod Autoscaler (HPA)                     | `true`                                           |
+| `hpa.minReplicas`                       | Minimum number of replicas                                 | `1`                                              |
+| `hpa.maxReplicas`                       | Maximum number of replicas                                 | `3`                                              |
+| `hpa.targetCPUUtilizationPercentage`    | Target CPU utilization percentage for HPA                  | `60`                                             |
+| `hpa.targetMemoryUtilizationPercentage` | Target memory utilization percentage for HPA               | `60`                                             |
+| `service.name`                          | Name of the Kubernetes service                             | `"lldap-service"`                                |
+| `service.type`                          | Service type                                               | `"ClusterIP"`                                    |
+| `service.ports`                         | List of service ports                                      | See `values.yaml`                                |
+| `ingress.enabled`                       | Enable Ingress                                             | `false`                                          |
+| `ingress.name`                          | Name of the Ingress resource                               | `"lldap-web-ingress"`                            |
+| `ingress.ingressClassName`              | Ingress class name                                         | `"nginx"`                                        |
+| `ingress.annotations`                   | Annotations for the Ingress                                | `{}`                                             |
+| `ingress.labels`                        | Labels for the Ingress                                     | `{}`                                             |
+| `ingress.hosts`                         | List of host configurations                                | See `values.yaml`                                |
+| `ingress.tls`                           | TLS configuration for the Ingress                          | See `values.yaml`                                |
+| `secret.create`                         | Create a new secret for credentials                        | `true`                                           |
+| `secret.name`                           | Name of the secret                                         | `"lldap-credentials"`                            |
+| `secret.lldapJwtSecret`                 | JWT secret for LLDAP                                       | `"wobY6RK/Dc0vL21zFiIZs9iyVy0NQ3ldijYPQ4HLWTc="` |
+| `secret.lldapUserName`                  | Username for the LDAP user                                 | `"admin"`                                        |
+| `secret.lldapUserPass`                  | Password for the LDAP user                                 | `"admiistrator123456"`                           |
+| `secret.lldapBaseDn`                    | Base DN for LDAP                                           | `"dc=homelab,dc=es"`                             |
+| `secret.useExisting`                    | Use an existing secret                                     | `false`                                          |
+| `secret.existingSecretName`             | Name of the existing secret                                | `""`                                             |
 
 ### How to Configure
 

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -65,6 +65,7 @@ spec:
             {{- end }}
           ports:
             - containerPort: 3890
+            - containerPort: 6360
             - containerPort: 17170
           volumeMounts:
             {{- if .Values.persistence.enabled }}

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -39,22 +39,22 @@ spec:
             - name: LLDAP_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lldap-credentials
+                  name: {{ .Values.secret.name }}
                   key: lldap-jwt-secret
             - name: LLDAP_LDAP_BASE_DN
               valueFrom:
                 secretKeyRef:
-                  name: lldap-credentials
+                  name: {{ .Values.secret.name }}
                   key: base-dn
             - name: LLDAP_LDAP_USER_DN
               valueFrom:
                 secretKeyRef:
-                  name: lldap-credentials
+                  name: {{ .Values.secret.name }}
                   key: lldap-ldap-user-name
             - name: LLDAP_LDAP_USER_PASS
               valueFrom:
                 secretKeyRef:
-                  name: lldap-credentials
+                  name: {{ .Values.secret.name }}
                   key: lldap-ldap-user-pass
             - name: TZ
               value: "{{ .Values.env.TZ }}"

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
               value: "{{ .Values.env.TZ }}"
             - name: UID
               value: "{{ .Values.env.UID }}"
+            {{- if .Values.extraEnv}}
+            {{- toYaml .Values.extraEnv | nindent 12}}
+            {{- end }}
           ports:
             - containerPort: 3890
             - containerPort: 17170

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -71,12 +71,20 @@ spec:
             - mountPath: /data
               name: lldap-data
             {{- end }}
-      {{- if .Values.persistence.enabled }}
+
+            {{- if .Values.extraVolumeMounts}}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12}}
+            {{- end }}
       volumes:
+        {{- if .Values.persistence.enabled}}
         - name: lldap-data
           persistentVolumeClaim:
             claimName: lldap-data
-      {{- end }}
+        {{- end }}
+
+        {{- if .Values.extraVolumes}}
+        {{- toYaml .Values.extraVolumes | nindent 8}}
+        {{- end }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/lldap-chart/values.yaml
+++ b/lldap-chart/values.yaml
@@ -25,6 +25,9 @@ persistence:
   # and if it does not supports automatic provisioning, set to true. Default is false
   manualProvision: false
 
+extraVolumes: []
+
+extraVolumeMounts: []
 
 ##### deployment
 # hour zone

--- a/lldap-chart/values.yaml
+++ b/lldap-chart/values.yaml
@@ -1,4 +1,4 @@
-##### secret creation 
+##### secret creation
 secret:
   create: true
   name: lldap-credentials
@@ -8,30 +8,32 @@ secret:
   lldapBaseDn: "dc=homelab,dc=es"
 
 
-##### pvc 
+##### pvc
 persistence:
-  enabled: true              
-  storageClassName: "" 
-  storageSize: "100Mi"        
-  accessMode: "ReadWriteOnce" 
+  enabled: true
+  storageClassName: ""
+  storageSize: "100Mi"
+  accessMode: "ReadWriteOnce"
 
   # in case the StorageClass used does not automatically provision volumes,
   # you can specify a local path for manual mounting here like for example /mnt/data/lldap
   # if the StorageClass supports automatic provisioning, leave this field empty.
   localPath: "" # Local filesystem path for storage, used if 'local-path' is the SC.
-  
+
   # if manualProvision is set to true, a persistentVolume is created with helm
   # if the StorageClass used supports automatic provisioning, this should be set to false.
   # and if it does not supports automatic provisioning, set to true. Default is false
-  manualProvision: false       
+  manualProvision: false
 
 
 ##### deployment
 # hour zone
-env:  
-  TZ: "CET"                 
+env:
+  TZ: "CET"
   GID: "1001"
   UID: "1001"
+
+extraEnv: []
 
 resources: {}
 #  limits:
@@ -58,11 +60,11 @@ image:
 # HPA configuration
 # make sure to use RWX storage class, if use 1 replica and not hpa
 hpa:
-  enabled: true  
-  minReplicas: 1  
+  enabled: true
+  minReplicas: 1
   maxReplicas: 3
   targetCPUUtilizationPercentage: 60
-  targetMemoryUtilizationPercentage: 60  
+  targetMemoryUtilizationPercentage: 60
 
 
 

--- a/lldap-chart/values.yaml
+++ b/lldap-chart/values.yaml
@@ -56,7 +56,7 @@ replicaCount: 1
 
 image:
   repository: "nitnelave/lldap"
-  tag: "latest"
+  tag: "v0.6.1"
   pullPolicy: "IfNotPresent"
 
 


### PR DESCRIPTION
Hi !

I wanted to deploy LLDAP with LDAPS (as shown in the [docker-compose](https://github.com/lldap/lldap?tab=readme-ov-file#with-docker)). This required setting additional env vars, mounting the certificate and exposing the LDAPS port.

I added the ability for setting:
- extraEnv
- extraVolumes
- extraVolumeMounts

In addition, I did some small fixes:
- If secret.name is set to something else than lldap-credentials, we should use secret.name
- Bumped Chart.yml version
- Set appVersion to latest LLDAP release and use the associated immutable tag for the image
- Put a chart description

The last three items are to prepare the chart for bundling/releasing into a repository, instead of having to include it using file://. I've successfully done that in my fork, but it needs some additional setup (github action setup, branch creation, github pages settings, etc...), let me know if you'd be interested !

Changes:
- feat: Do not hardcode secret_name in deployment
- feat: Allow setting extra env vars
- feat: Allow setting extra volumes and volumemounts
- fix: Expose LDAPS port
- feat: Align appVersion on lldap image tag
- fix: Chart description

PS : Let me know if you'd prefer me opening a separate PR for each of the commits.