### PR TITLE
Ci/add chart release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: List files
+        run: |
+          ls -la ./lldap-chart
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: ./
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -59,3 +59,41 @@ And in your browser go to http://127.0.0.1:17170. Login with admin and the passw
 For creating user and groups, please look at the LLDAP documentation at https://github.com/nitnelave/lldap
 
 Good luck!
+
+## Using the helm chart
+
+### Required values and recommended values
+
+Always create your own secrets and usernames:
+```yaml
+secret:
+  lldapJwtSecret: "replace-me"
+  lldapUserName: "admin" # this has a default value but can be overridden
+  lldapUserPass: "replace-me"
+  lldapBaseDn: "dc=homelab,dc=home" # this has a default value but can be overridden
+```
+
+Set your own ingress values:
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations: {}
+  labels: {}
+  hosts:
+    - host: "lldap.test.com"
+      paths:
+        - path: "/"
+          pathType: "Prefix"
+  tls:
+    - secretName: "lldap-secret-tls"
+      hosts:
+        - "lldap.test.com"
+```
+
+### Install the chart
+
+```bash
+```
+helm install lldap-chart https://github.com/Evantage-WS/lldap-kubernetes/releases/download/lldap-chart-0.3.4/lldap-chart-0.3.4.tgz
+```

--- a/lldap-chart/Chart.yaml
+++ b/lldap-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/lldap-chart/Chart.yaml
+++ b/lldap-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/lldap-chart/templates/_helpers.tpl
+++ b/lldap-chart/templates/_helpers.tpl
@@ -31,6 +31,14 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Define image tag to use - use .Values.image.tag if defined, otherwise use AppVersion
+*/}}
+{{- define "lldap-chart.imageTag" -}}
+{{- $vAppVersion := (printf "v%s" .Chart.AppVersion) }}
+{{- .Values.image.tag | default $vAppVersion }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "lldap-chart.labels" -}}

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -1,10 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: lldap
+  name: {{ include "lldap-chart.fullname" . }}-deployment
   namespace: {{ .Values.namespace }}
   labels:
     app: lldap
+    {{- include "lldap-chart.labels" . | nindent 4 }}
   annotations:
     lldap: https://github.com/nitnelave/lldap
     k8s: https://github.com/Evantage-WS/lldap-kubernetes
@@ -19,6 +20,7 @@ spec:
     metadata:
       labels:
         app: lldap
+        {{- include "lldap-chart.selectorLabels" . | nindent 8 }}
       annotations:
         lldap: https://github.com/nitnelave/lldap
         k8s: https://github.com/Evantage-WS/lldap-kubernetes
@@ -39,22 +41,22 @@ spec:
             - name: LLDAP_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secret.name }}
+                  name: {{ include "lldap-chart.fullname" . }}-secret
                   key: lldap-jwt-secret
             - name: LLDAP_LDAP_BASE_DN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secret.name }}
+                  name: {{ include "lldap-chart.fullname" . }}-secret
                   key: base-dn
             - name: LLDAP_LDAP_USER_DN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secret.name }}
+                  name: {{ include "lldap-chart.fullname" . }}-secret
                   key: lldap-ldap-user-name
             - name: LLDAP_LDAP_USER_PASS
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secret.name }}
+                  name: {{ include "lldap-chart.fullname" . }}-secret
                   key: lldap-ldap-user-pass
             - name: TZ
               value: "{{ .Values.env.TZ }}"
@@ -80,7 +82,7 @@ spec:
         {{- if .Values.persistence.enabled}}
         - name: lldap-data
           persistentVolumeClaim:
-            claimName: lldap-data
+            claimName: {{ include "lldap-chart.fullname" . }}-data
         {{- end }}
 
         {{- if .Values.extraVolumes}}

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: lldap
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ include "lldap-chart.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 
           {{- with .Values.resources }}

--- a/lldap-chart/templates/hpa.yaml
+++ b/lldap-chart/templates/hpa.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ .Release.Name }}-hpa
+  name: {{ include "lldap-chart.fullname" . }}-hpa
   namespace: {{ .Values.namespace }}
 spec:
   scaleTargetRef:

--- a/lldap-chart/templates/ingress.yaml
+++ b/lldap-chart/templates/ingress.yaml
@@ -2,10 +2,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Values.ingress.name }}
+  name: {{ include "lldap-chart.fullname" . }}-ingress
   namespace: {{ .Values.namespace }}
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
 {{- if .Values.ingress.labels }}
   labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
@@ -22,7 +22,7 @@ spec:
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ $.Values.service.name }}
+                name: {{ include "lldap-chart.fullname" $ }}-service
                 port:
                   number: 17170
         {{- end }}

--- a/lldap-chart/templates/pvc.yaml
+++ b/lldap-chart/templates/pvc.yaml
@@ -2,10 +2,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: lldap-data
+  name: {{ include "lldap-chart.fullname" . }}-data
   namespace: {{ .Values.namespace }}
   labels:
     app: lldap
+    {{- include "lldap-chart.labels" . | nindent 4 }}
 spec:
   {{- if .Values.persistence.storageClassName }}
   storageClassName: {{ .Values.persistence.storageClassName }}
@@ -21,10 +22,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: lldap-data-pv
+  name: {{ include "lldap-chart.fullname" . }}-data-pv
   namespace: {{ .Values.namespace }}
   labels:
     app: lldap
+    {{- include "lldap-chart.labels" . | nindent 4 }}
 spec:
   capacity:
     storage: {{ .Values.persistence.storageSize }}

--- a/lldap-chart/templates/secret.yaml
+++ b/lldap-chart/templates/secret.yaml
@@ -2,8 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secret.name }}
+  name: {{ include "lldap-chart.fullname" . }}-secret
   namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "lldap-chart.labels" . | nindent 4 }}
 type: Opaque
 data:
   lldap-jwt-secret: {{ required "secret.lldapJwtSecret is required" .Values.secret.lldapJwtSecret | b64enc }}

--- a/lldap-chart/templates/secret.yaml
+++ b/lldap-chart/templates/secret.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ .Values.namespace }}
 type: Opaque
 data:
-  lldap-jwt-secret: {{ .Values.secret.lldapJwtSecret | b64enc }}
+  lldap-jwt-secret: {{ required "secret.lldapJwtSecret is required" .Values.secret.lldapJwtSecret | b64enc }}
   lldap-ldap-user-name: {{ .Values.secret.lldapUserName | b64enc }}
-  lldap-ldap-user-pass: {{ .Values.secret.lldapUserPass | b64enc }}
+  lldap-ldap-user-pass: {{ required "secret.lldapUserPass is required" .Values.secret.lldapUserPass | b64enc }}
   base-dn: {{ .Values.secret.lldapBaseDn | b64enc }}
 {{- end }}

--- a/lldap-chart/templates/service.yaml
+++ b/lldap-chart/templates/service.yaml
@@ -1,16 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.service.name }}
+  name: {{ include "lldap-chart.fullname" . }}-service
   namespace: {{ .Values.namespace }}
   labels:
     app: lldap
+    {{- include "lldap-chart.labels" . | nindent 4 }}
   annotations:
     lldap: https://github.com/nitnelave/lldap
     k8s: https://github.com/Evantage-WS/lldap-kubernetes
 spec:
   type: {{ .Values.service.type }}
   ports:
-{{ toYaml .Values.service.ports | indent 4 }}
+    {{- toYaml .Values.service.ports | nindent 4 }}
   selector:
+    {{- include "lldap-chart.selectorLabels" . | nindent 4 }}
     app: lldap

--- a/lldap-chart/values.yaml
+++ b/lldap-chart/values.yaml
@@ -55,7 +55,7 @@ replicaCount: 1
 
 image:
   repository: "nitnelave/lldap"
-  tag: "v0.6.1"
+  # tag: "v0.6.1"
   pullPolicy: "IfNotPresent"
 
 

--- a/lldap-chart/values.yaml
+++ b/lldap-chart/values.yaml
@@ -2,11 +2,10 @@
 secret:
   create: true
   name: lldap-credentials
-  lldapJwtSecret: "wobY6RK/Dc0vL21zFiIZs9iyVy0NQ3ldijYPQ4HLWTc="
+  # lldapJwtSecret: "replace-me"
   lldapUserName: "admin"
-  lldapUserPass: "admiistrator123456"
-  lldapBaseDn: "dc=homelab,dc=es"
-
+  # lldapUserPass: "replace-me"
+  lldapBaseDn: "dc=homelab,dc=home"
 
 ##### pvc
 persistence:

--- a/lldap-chart/values.yaml
+++ b/lldap-chart/values.yaml
@@ -85,7 +85,7 @@ service:
 
 #####ingress
 ingress:
-  enabled: false
+  enabled: true
   name: lldap-web-ingress
   ingressClassName: nginx
   annotations: {}


### PR DESCRIPTION
I started using this chart and noticed it is not published yet. To make it a little bit easier I added the GHA helm chart releaser, which publishes the chart as an artifact. This url can then easily be used as chart path with an helm install. I am using my own fork releases already this way.
The only thing you need to change on the repository is adding an empty `gh-pages` branch, where it can publish to.

```bash
git checkout --orphan gh-pages
git rm -rf .
git commit --allow-empty -m "Initial empty gh-pages commit"
git push origin gh-pages
```

I also made the chart a little bit more generic, so it be used to deploy multiple release in the same namespace.
And I removed some default secrets, as I think it is bad practice to have default secret on such an important service. When ppl forget to change these things they are vulnerable...