### PR TITLE
Add support for existing secrets

### DIFF
--- a/lldap-chart/README.md
+++ b/lldap-chart/README.md
@@ -93,7 +93,6 @@ The following table lists the configurable parameters of the lldap chart and the
 | `secret.lldapUserPass`                  | Password for the LDAP user                                 | `"admiistrator123456"`                           |
 | `secret.lldapBaseDn`                    | Base DN for LDAP                                           | `"dc=homelab,dc=es"`                             |
 | `secret.useExisting`                    | Use an existing secret                                     | `false`                                          |
-| `secret.existingSecretName`             | Name of the existing secret                                | `""`                                             |
 
 ### How to Configure
 

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -41,22 +41,22 @@ spec:
             - name: LLDAP_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
+                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.name }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: lldap-jwt-secret
             - name: LLDAP_LDAP_BASE_DN
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
+                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.name }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: base-dn
             - name: LLDAP_LDAP_USER_DN
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
+                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.name }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: lldap-ldap-user-name
             - name: LLDAP_LDAP_USER_PASS
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
+                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.name }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: lldap-ldap-user-pass
             - name: TZ
               value: "{{ .Values.env.TZ }}"

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -41,22 +41,22 @@ spec:
             - name: LLDAP_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lldap-chart.fullname" . }}-secret
+                  name: {{- if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: lldap-jwt-secret
             - name: LLDAP_LDAP_BASE_DN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lldap-chart.fullname" . }}-secret
+                  name: {{- if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: base-dn
             - name: LLDAP_LDAP_USER_DN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lldap-chart.fullname" . }}-secret
+                  name: {{- if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: lldap-ldap-user-name
             - name: LLDAP_LDAP_USER_PASS
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lldap-chart.fullname" . }}-secret
+                  name: {{- if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: lldap-ldap-user-pass
             - name: TZ
               value: "{{ .Values.env.TZ }}"

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -41,22 +41,22 @@ spec:
             - name: LLDAP_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{- if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
+                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: lldap-jwt-secret
             - name: LLDAP_LDAP_BASE_DN
               valueFrom:
                 secretKeyRef:
-                  name: {{- if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
+                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: base-dn
             - name: LLDAP_LDAP_USER_DN
               valueFrom:
                 secretKeyRef:
-                  name: {{- if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
+                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: lldap-ldap-user-name
             - name: LLDAP_LDAP_USER_PASS
               valueFrom:
                 secretKeyRef:
-                  name: {{- if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
+                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.existingSecret }}{{ else }}{{ include "lldap-chart.fullname" . }}-secret{{ end }}
                   key: lldap-ldap-user-pass
             - name: TZ
               value: "{{ .Values.env.TZ }}"

--- a/lldap-chart/values.yaml
+++ b/lldap-chart/values.yaml
@@ -1,6 +1,7 @@
 ##### secret creation
 secret:
   create: true
+  useExisting: false
   name: lldap-credentials
   # lldapJwtSecret: "replace-me"
   lldapUserName: "admin"
@@ -99,5 +100,3 @@ ingress:
     - secretName: "lldap-secret-tls"
       hosts:
         - "lldap.test.com"
-
-


### PR DESCRIPTION
Seems like there was a push a few weeks ago that hard coded the secret breaking installs where secrets are managed independently. This brings back that behavior through `.secret.useExisting` and `.secret.name`. 

If `useExisting` is true `.secret.name` will be used, otherwise generate one with the helm chart name.

Also added the option to the values file and removed `.secret.existingSecretName` since this doesn't appear to be used anywhere and does the same job as `.secret.name`