### PR TITLE
Add support for custom certs

### DIFF
--- a/lldap-chart/README.md
+++ b/lldap-chart/README.md
@@ -60,6 +60,9 @@ The following table lists the configurable parameters of the lldap chart and the
 | `env.TZ`                                | Timezone for the application                               | `"CET"`                                          |
 | `env.GID`                               | Group ID                                                   | `"1001"`                                         |
 | `env.UID`                               | User ID                                                    | `"1001"`                                         |
+| `env.LDAPS_OPTIONS__ENABLED`            | Enable LDAPS configuration options                         | `false`                                          |
+| `env.LDAPS_OPTIONS__CERT_FILE`          | LDAPS certificate file path                                | `"/path/to/certfile.crt"`                        |
+| `env.LDAPS_OPTIONS__KEY_FILE`           | LDAPS key file path                                        | `"/path/to/keyfile.key"`                         |
 | `extraEnv`                              | Extra environment variables to be set on lldap container   | `[]`                                             |
 | `persistence.enabled`                   | Enable persistent storage                                  | `true`                                           |
 | `persistence.storageClassName`          | Storage class name                                         | `""`                                             |

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -43,11 +43,6 @@ spec:
                 secretKeyRef:
                   name: {{ if .Values.secret.useExisting }}{{ .Values.secret.name }}{{ else }}{{ include "lldap.fullname" . }}{{ end }}
                   key: lldap-jwt-secret
-            - name: LLDAP_KEY_SEED
-              valueFrom:
-                secretKeyRef:
-                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.name }}{{ else }}{{ include "lldap.fullname" . }}{{ end }}
-                  key: lldap-key-seed
             - name: LLDAP_LDAP_BASE_DN
               valueFrom:
                 secretKeyRef:
@@ -63,6 +58,20 @@ spec:
                 secretKeyRef:
                   name: {{ if .Values.secret.useExisting }}{{ .Values.secret.name }}{{ else }}{{ include "lldap.fullname" . }}{{ end }}
                   key: lldap-ldap-user-pass
+            {{- if .Values.env.LDAPS_OPTIONS__ENABLED }}
+            - name: LLDAP_LDAPS_OPTIONS__ENABLED
+              value: {{ .Values.env.LDAPS_OPTIONS__ENABLED }}
+            - name: LLDAP_LDAPS_OPTIONS__CERT_FILE
+              value: {{ .Values.env.LDAPS_OPTIONS__CERT_FILE}}
+            - name: LLDAP_LDAPS_OPTIONS__KEY_FILE
+              value: {{ .Values.env.LDAPS_OPTIONS__KEY_FILE}}
+            {{- else }}
+            - name: LLDAP_KEY_SEED
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.secret.useExisting }}{{ .Values.secret.name }}{{ else }}{{ include "lldap.fullname" . }}{{ end }}
+                  key: lldap-key-seed
+            {{- end }}
             {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -60,11 +60,11 @@ spec:
                   key: lldap-ldap-user-pass
             {{- if .Values.env.LDAPS_OPTIONS__ENABLED }}
             - name: LLDAP_LDAPS_OPTIONS__ENABLED
-              value: {{ .Values.env.LDAPS_OPTIONS__ENABLED }}
+              value: {{ .Values.env.LDAPS_OPTIONS__ENABLED | quote }}
             - name: LLDAP_LDAPS_OPTIONS__CERT_FILE
-              value: {{ .Values.env.LDAPS_OPTIONS__CERT_FILE}}
+              value: {{ .Values.env.LDAPS_OPTIONS__CERT_FILE }}
             - name: LLDAP_LDAPS_OPTIONS__KEY_FILE
-              value: {{ .Values.env.LDAPS_OPTIONS__KEY_FILE}}
+              value: {{ .Values.env.LDAPS_OPTIONS__KEY_FILE }}
             {{- else }}
             - name: LLDAP_KEY_SEED
               valueFrom:

--- a/lldap-chart/values.yaml
+++ b/lldap-chart/values.yaml
@@ -34,6 +34,9 @@ env:
   TZ: "CET"
   GID: "1001"
   UID: "1001"
+  LDAPS_OPTIONS__ENABLED: false
+  LDAPS_OPTIONS__CERT_FILE: "/path/to/certfile.crt"
+  LDAPS_OPTIONS__KEY_FILE: "/path/to/keyfile.key"
 
 extraEnv: []
 


### PR DESCRIPTION
PR #16 broke bring your own cert scenarios by forcing the use of a key seed. This change adds LDAPS_OPTIONS env variables to the chart and disables the use of key seed, when `env.LDAPS_OPTIONS__ENABLED` is `true`.