### PR TITLE
Allowing existing volume claim to be used

### DIFF
--- a/lldap-chart/README.md
+++ b/lldap-chart/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the lldap chart and the
 | `env.LDAPS_OPTIONS__KEY_FILE`           | LDAPS key file path                                        | `"/path/to/keyfile.key"`                         |
 | `extraEnv`                              | Extra environment variables to be set on lldap container   | `[]`                                             |
 | `persistence.enabled`                   | Enable persistent storage                                  | `true`                                           |
+| `persistence.existingVolumeClaim`       | Existing PVC name                                          | `""`                                             |
 | `persistence.storageClassName`          | Storage class name                                         | `""`                                             |
 | `persistence.storageSize`               | Storage size                                               | `"100Mi"`                                        |
 | `persistence.accessMode`                | Access mode for the PVC                                    | `"ReadWriteOnce"`                                |

--- a/lldap-chart/templates/deployment.yaml
+++ b/lldap-chart/templates/deployment.yaml
@@ -89,9 +89,15 @@ spec:
             {{- end }}
       volumes:
         {{- if .Values.persistence.enabled }}
+          {{- if .Values.persistence.existingVolumeClaim }}
+        - name: lldap-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingVolumeClaim }}
+          {{- else }}
         - name: lldap-data
           persistentVolumeClaim:
             claimName: {{ include "lldap.fullname" . }}
+          {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/lldap-chart/templates/pvc.yaml
+++ b/lldap-chart/templates/pvc.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingVolumeClaim) -}}
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -17,7 +18,7 @@ spec:
       storage: {{ .Values.persistence.storageSize }}
 {{- end }}
 
-{{- if and .Values.persistence.enabled .Values.persistence.manualProvision }}
+{{- if and .Values.persistence.enabled .Values.persistence.manualProvision (not .Values.persistence.existingVolumeClaim)}}
 ---
 apiVersion: v1
 kind: PersistentVolume

--- a/lldap-chart/values.yaml
+++ b/lldap-chart/values.yaml
@@ -12,6 +12,12 @@ secret:
 ##### PersistentVolumeClaim configuration
 persistence:
   enabled: true
+  
+  # if existingVolumeClaim is set to the name of a PVC in the namespace, this will be used, 
+  # instead of creating a new one.
+
+  existingVolumeClaim: ""
+
   storageClassName: ""
   storageSize: "100Mi"
   accessMode: "ReadWriteOnce"


### PR DESCRIPTION
This PR allows a user to add the name of an existing PersistentVolumeClaim to `values.yaml`. This PVC will then be mounted as `/data/` instead of a new PVC and PV being automatically created. This is very useful for people who manage their own storage (ie with Longhorn), or as part of disaster recovery.

#values.yaml
```
....
##### PersistentVolumeClaim configuration
persistence:
  enabled: true
  existingVolumeClaim: "my-existing-lldap-volume"
...
```

```
Volumes:
  lldap-data:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  my-existing-lldap-volume
    ReadOnly:   false
```