### PR TITLE
Use service name from values file

### DIFF
--- a/charts/lldap/templates/service.yaml
+++ b/charts/lldap/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "lldap.fullname" . }}
+  name: {{ .Values.service.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "lldap.labels" . | nindent 4 }}

--- a/charts/lldap/values.yaml
+++ b/charts/lldap/values.yaml
@@ -76,6 +76,7 @@ hpa:
 
 ##### Service definition
 service:
+  name: lldap-service
   type: ClusterIP
   annotations: {}
   ports:


### PR DESCRIPTION
The README.md for the chart says that you can change the name of the service by setting `service.name` in the `values.yaml` file but the template doesn't actually use that particular field.  This updates the template to use the name specified.